### PR TITLE
Add Microsoft Foundry as a default LLM connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ New-Item -Type Directory -Path $REPOSITORY_ROOT/src/InterviewCoach.Mcp.MarkItDow
     git clone https://github.com/microsoft/markitdown $REPOSITORY_ROOT/src/InterviewCoach.Mcp.MarkItDown
 ```
 
-<details open>
-<summary><h3>Use Microsoft Foundry</h3></summary>
+### Set Connection to LLM
 
-<!-- ### Use Microsoft Foundry -->
+<details open>
+<summary><strong>Use Microsoft Foundry</strong></summary>
 
 1. Get the project endpoint and API key from [Foundry Portal](https://ai.azure.com).
 1. Store both endpoint and API key to user secrets.
@@ -74,9 +74,7 @@ New-Item -Type Directory -Path $REPOSITORY_ROOT/src/InterviewCoach.Mcp.MarkItDow
 </details>
 
 <details>
-<summary><h3>Use Azure OpenAI</h3></summary>
-
-<!-- ### Use Azure OpenAI -->
+<summary><strong>Use Azure OpenAI</strong></summary>
 
 1. Get the endpoint and API key from [Foundry Portal](https://ai.azure.com).
 1. Store both endpoint and API key to user secrets.
@@ -105,9 +103,7 @@ New-Item -Type Directory -Path $REPOSITORY_ROOT/src/InterviewCoach.Mcp.MarkItDow
 </details>
 
 <details>
-<summary><h3>Use GitHub Models</h3></summary>
-
-<!-- ### Use GitHub Models -->
+<summary><strong>Use GitHub Models</strong></summary>
 
 1. Get the [GitHub Personal Access Token (PAT)](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token) to access to [GitHub Models](https://github.com/marketplace?type=models).
 1. Store the GitHub PAT to user secrets.

--- a/README.md
+++ b/README.md
@@ -40,52 +40,45 @@ New-Item -Type Directory -Path $REPOSITORY_ROOT/src/InterviewCoach.Mcp.MarkItDow
     git clone https://github.com/microsoft/markitdown $REPOSITORY_ROOT/src/InterviewCoach.Mcp.MarkItDown
 ```
 
-### Use GitHub Models
+<details open>
+<summary><h3>Use Microsoft Foundry</h3></summary>
 
-1. Get the [GitHub Personal Access Token (PAT)](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token) to access to [GitHub Models](https://github.com/marketplace?type=models).
+<!-- ### Use Microsoft Foundry -->
 
-1. Store the GitHub PAT to user secrets.
+1. Get the project endpoint and API key from [Foundry Portal](https://ai.azure.com).
+1. Store both endpoint and API key to user secrets.
 
     ```bash
-    dotnet user-secrets --file ./apphost.cs set GitHub:Token {{GITHUB_PAT}}
+    dotnet user-secrets --file ./apphost.cs set MicrosoftFoundry:Project:Endpoint $MICROSOFT_FOUNDRY_PROJECT_ENDPOINT
+    dotnet user-secrets --file ./apphost.cs set MicrosoftFoundry:Project:ApiKey $MICROSOFT_FOUNDRY_PROJECT_API_KEY
     ```
 
-1. Make sure that `src/InterviewCoach.AppHost/appsettings.json` or `apphost.settings.json` points to use GitHub Models. You can change the default model from `openai/gpt-5-mini` to your preferred one.
+1. Make sure that `src/InterviewCoach.AppHost/appsettings.json` or `apphost.settings.json` points to use Azure OpenAI. You can change the default model from `model-router` to your preferred one.
 
     ```jsonc
     {
-      "LlmProvider": "GitHubModels",
+      "LlmProvider": "MicrosoftFoundry",
 
-      "GitHub": {
-        "Endpoint": "https://models.github.ai/inference",
-        "Token": "{{GITHUB_PAT}}",
-        "Model": "openai/gpt-5-mini"
+      "MicrosoftFoundry": {
+        "Project": {
+          "Endpoint": "{{MICROSOFT_FOUNDRY_PROJECT_ENDPOINT}}",
+          "ApiKey": "{{MICROSOFT_FOUNDRY_PROJECT_API_KEY}}",
+          "DeploymentName": "model-router"
+        }
       }
     }
     ```
 
-### Use Azure OpenAI
+   > **NOTE**: You can find more about [Model Router](https://learn.microsoft.com/azure/ai-foundry/openai/concepts/model-router?view=foundry) on Microsoft Foundry.
 
-1. Login to Azure
+</details>
 
-    ```bash
-    az login
-    ```
+<details>
+<summary><h3>Use Azure OpenAI</h3></summary>
 
-1. Assuming you've already got an active [Azure OpenAI](https://azure.microsoft.com/products/ai-foundry/models/openai) instance. Get both endpoint and API from that instance.
+<!-- ### Use Azure OpenAI -->
 
-    ```bash
-    # zsh/bash
-    AZURE_OPENAI_ENDPOINT=$(az cognitiveservices account show -g rg-juyoo-aoai -n openai-6heq7tc4w2ols --query "properties.endpoint" -o tsv)
-    AZURE_OPENAI_API_KEY=$(az cognitiveservices account keys list -g rg-juyoo-aoai -n openai-6heq7tc4w2ols --query "key1" -o tsv)
-    ```
-
-    ```powershell
-    # PowerShell
-    $AZURE_OPENAI_ENDPOINT = az cognitiveservices account show -g rg-juyoo-aoai -n openai-6heq7tc4w2ols --query "properties.endpoint" -o tsv
-    $AZURE_OPENAI_API_KEY = az cognitiveservices account keys list -g rg-juyoo-aoai -n openai-6heq7tc4w2ols --query "key1" -o tsv
-    ```
-
+1. Get the endpoint and API key from [Foundry Portal](https://ai.azure.com).
 1. Store both endpoint and API key to user secrets.
 
     ```bash
@@ -109,6 +102,36 @@ New-Item -Type Directory -Path $REPOSITORY_ROOT/src/InterviewCoach.Mcp.MarkItDow
     }
     ```
 
+</details>
+
+<details>
+<summary><h3>Use GitHub Models</h3></summary>
+
+<!-- ### Use GitHub Models -->
+
+1. Get the [GitHub Personal Access Token (PAT)](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token) to access to [GitHub Models](https://github.com/marketplace?type=models).
+1. Store the GitHub PAT to user secrets.
+
+    ```bash
+    dotnet user-secrets --file ./apphost.cs set GitHub:Token {{GITHUB_PAT}}
+    ```
+
+1. Make sure that `src/InterviewCoach.AppHost/appsettings.json` or `apphost.settings.json` points to use GitHub Models. You can change the default model from `openai/gpt-5-mini` to your preferred one.
+
+    ```jsonc
+    {
+      "LlmProvider": "GitHubModels",
+
+      "GitHub": {
+        "Endpoint": "https://models.github.ai/inference",
+        "Token": "{{GITHUB_PAT}}",
+        "Model": "openai/gpt-5-mini"
+      }
+    }
+    ```
+
+</details>
+
 ### Run Aspire
 
 You can run Aspire from either way - file-based `apphost.cs` or project-based `AppHost.csproj`.
@@ -116,13 +139,13 @@ You can run Aspire from either way - file-based `apphost.cs` or project-based `A
 1. Run Aspire from the file-based `apphost.cs`.
 
     ```bash
-    dotnet run --file ./apphost.cs
+    aspire run --file ./apphost.cs
     ```
 
 1. Run Aspire from the project-based `AppHost.csproj`.
 
     ```bash
-    dotnet run --project ./src/InterviewCoach.AppHost
+    aspire run --project ./src/InterviewCoach.AppHost
     ```
 
 1. Open Aspire dashboard then navigate to the `webui` instance to run the interview coach app.
@@ -153,11 +176,25 @@ You can run Aspire from either way - file-based `apphost.cs` or project-based `A
 
 ## Additional Resources
 
+### Microsoft Foundry
+
+- [Microsoft Foundry](https://learn.microsoft.com/azure/ai-foundry/what-is-foundry?view=foundry)
+- [Microsoft Foundry Agent Service](https://learn.microsoft.com/azure/ai-foundry/agents/overview?view=foundry)
+- [Microsoft Foundry Model Router](https://learn.microsoft.com/azure/ai-foundry/openai/concepts/model-router?view=foundry)
+
+### Microsoft Agent Framework
+
 - [Microsoft Agent Framework](https://aka.ms/agent-framework)
 - [Multi-Agent Orchestration Pattern](https://learn.microsoft.com/agent-framework/user-guide/workflows/orchestrations/overview)
 - [AG-UI Protocol](https://docs.ag-ui.com/introduction)
+
+### MCP Server
+
 - [MarkItDown MCP Server](https://github.com/microsoft/markitdown/tree/main/packages/markitdown-mcp)
-- [Aspire](https://aspire.dev)
 <!-- - [Outlook Email MCP Server](https://github.com/microsoft/mcp-dotnet-samples/tree/main/outlook-email)
 - [OneDrive Download MCP Server](https://github.com/microsoft/mcp-dotnet-samples/tree/main/onedrive-download)
 - [Google Drive Download MCP Server](https://github.com/microsoft/mcp-dotnet-samples/tree/main/googledrive-download) -->
+
+### Aspire
+
+- [Aspire](https://aspire.dev)

--- a/apphost.cs
+++ b/apphost.cs
@@ -1,4 +1,5 @@
-#:sdk Aspire.AppHost.Sdk@13.1.0
+#:sdk Aspire.AppHost.Sdk@13.1.1
+#:package Aspire.Hosting.Azure@13.*
 #:package Aspire.Hosting.GitHub.Models@13.*
 #:package Aspire.Hosting.OpenAI@13.*
 #:package CommunityToolkit.Aspire.Hosting.SQLite@13.*
@@ -9,6 +10,7 @@
 
 using Microsoft.Extensions.Configuration;
 
+const string RESOURCE_CONSTANTS_LLM_PROVIDER = "LlmProvider";
 const string RESOURCE_MCP_MARKITDOWN = "mcp-markitdown";
 const string RESOURCE_MCP_INTERVIEWDATA = "mcp-interview-data";
 const string RESOURCE_DB_SQLITE = "sqlite";
@@ -17,6 +19,8 @@ const string RESOURCE_PROJECT_AGENT = "agent";
 const string RESOURCE_PROJECT_WEBUI = "webui";
 
 var builder = DistributedApplication.CreateBuilder(args);
+
+// var foundry = builder.AddBicepTemplate("foundry", "./infra/foundry.bicep");
 
 var config = builder.Configuration
                     .AddJsonFile("apphost.settings.json", optional: true, reloadOnChange: true)
@@ -40,6 +44,7 @@ var mcpInterviewData = builder.AddProject<Projects.InterviewCoach_Mcp_InterviewD
 var agent = builder.AddProject<Projects.InterviewCoach_Agent>(RESOURCE_PROJECT_AGENT)
                    .WithExternalHttpEndpoints()
                    .WithLlmReference(builder.Configuration)
+                   .WithEnvironment(RESOURCE_CONSTANTS_LLM_PROVIDER, builder.Configuration[RESOURCE_CONSTANTS_LLM_PROVIDER] ?? string.Empty)
                    .WithReference(mcpMarkItDown.GetEndpoint("http"))
                    .WithReference(mcpInterviewData)
                    .WaitFor(mcpMarkItDown)
@@ -57,14 +62,17 @@ public static class LlmResourceFactory
     private const string LLM_PROVIDER_KEY = "LlmProvider";
     private const string LLM_PROVIDER_GITHUB = "GitHubModels";
     private const string LLM_PROVIDER_AZURE_OPENAI = "AzureOpenAI";
+    private const string LLM_PROVIDER_MICROSOFT_FOUNDRY = "MicrosoftFoundry";
     private const string SECTION_NAME_GITHUB = "GitHub";
     private const string SECTION_NAME_AZURE_OPENAI = "Azure:OpenAI";
+    private const string SECTION_NAME_MICROSOFT_FOUNDRY = "MicrosoftFoundry:Project";
     private const string ENDPOINT_KEY = "Endpoint";
     private const string TOKEN_KEY = "Token";
     private const string API_KEY_KEY = "ApiKey";
     private const string MODEL_KEY = "Model";
     private const string DEPLOYMENT_NAME_KEY = "DeploymentName";
     private const string API_KEY_RESOURCE_NAME = "apiKey";
+    private const string LLM_PROJECT_NAME = "foundry";
     private const string LLM_SERVICE_NAME = "openai";
     private const string LLM_RESOURCE_NAME = "chat";
 
@@ -75,10 +83,34 @@ public static class LlmResourceFactory
         {
             LLM_PROVIDER_GITHUB => AddGitHubModelsResource(source, config),
             LLM_PROVIDER_AZURE_OPENAI => AddAzureOpenAIResource(source, config),
+            LLM_PROVIDER_MICROSOFT_FOUNDRY => AddMicrosoftFoundryResource(source, config),
             _ => throw new NotSupportedException($"The specified LLM provider '{provider}' is not supported.")
         };
 
         return source;
+    }
+
+    private static IResourceBuilder<ProjectResource> AddGitHubModelsResource(IResourceBuilder<ProjectResource> source, IConfiguration config)
+    {
+        var provider = config["LlmProvider"];
+
+        var github = config.GetSection(SECTION_NAME_GITHUB);
+        var endpoint = github[ENDPOINT_KEY] ?? throw new InvalidOperationException($"Missing configuration: {SECTION_NAME_GITHUB}:{ENDPOINT_KEY}");
+        var token = github[TOKEN_KEY] ?? throw new InvalidOperationException($"Missing configuration: {SECTION_NAME_GITHUB}:{TOKEN_KEY}");
+        var model = github[MODEL_KEY] ?? throw new InvalidOperationException($"Missing configuration: {SECTION_NAME_GITHUB}:{MODEL_KEY}");
+
+        Console.WriteLine();
+        Console.WriteLine($"\tUsing {provider}: {model}");
+        Console.WriteLine();
+
+        var apiKey = source.ApplicationBuilder
+                           .AddParameter(name: API_KEY_RESOURCE_NAME, value: token, secret: true);
+        var chat = source.ApplicationBuilder
+                         .AddGitHubModel(name: LLM_RESOURCE_NAME, model: model)
+                         .WithApiKey(apiKey);
+
+        return source.WithReference(chat)
+                     .WaitFor(chat);
     }
 
     private static IResourceBuilder<ProjectResource> AddAzureOpenAIResource(IResourceBuilder<ProjectResource> source, IConfiguration config)
@@ -105,25 +137,26 @@ public static class LlmResourceFactory
                      .WaitFor(chat);
     }
 
-    private static IResourceBuilder<ProjectResource> AddGitHubModelsResource(IResourceBuilder<ProjectResource> source, IConfiguration config)
+    private static IResourceBuilder<ProjectResource> AddMicrosoftFoundryResource(IResourceBuilder<ProjectResource> source, IConfiguration config)
     {
-        var provider = config["LlmProvider"];
+        var provider = config[LLM_PROVIDER_KEY];
 
-        var github = config.GetSection(SECTION_NAME_GITHUB);
-        var endpoint = github[ENDPOINT_KEY] ?? throw new InvalidOperationException($"Missing configuration: {SECTION_NAME_GITHUB}:{ENDPOINT_KEY}");
-        var token = github[TOKEN_KEY] ?? throw new InvalidOperationException($"Missing configuration: {SECTION_NAME_GITHUB}:{TOKEN_KEY}");
-        var model = github[MODEL_KEY] ?? throw new InvalidOperationException($"Missing configuration: {SECTION_NAME_GITHUB}:{MODEL_KEY}");
+        var foundry = config.GetSection(SECTION_NAME_MICROSOFT_FOUNDRY);
+        var endpoint = foundry[ENDPOINT_KEY] ?? throw new InvalidOperationException($"Missing configuration: {SECTION_NAME_MICROSOFT_FOUNDRY}:{ENDPOINT_KEY}");
+        var accessKey = foundry[API_KEY_KEY] ?? throw new InvalidOperationException($"Missing configuration: {SECTION_NAME_MICROSOFT_FOUNDRY}:{API_KEY_KEY}");
+        var deploymentName = foundry[DEPLOYMENT_NAME_KEY] ?? throw new InvalidOperationException($"Missing configuration: {SECTION_NAME_MICROSOFT_FOUNDRY}:{DEPLOYMENT_NAME_KEY}");
 
         Console.WriteLine();
-        Console.WriteLine($"\tUsing {provider}: {model}");
+        Console.WriteLine($"\tUsing {provider}: {deploymentName}");
         Console.WriteLine();
 
         var apiKey = source.ApplicationBuilder
-                           .AddParameter(name: API_KEY_RESOURCE_NAME, value: token, secret: true);
+                           .AddParameter(name: API_KEY_RESOURCE_NAME, value: accessKey, secret: true);
         var chat = source.ApplicationBuilder
-                         .AddGitHubModel(name: LLM_RESOURCE_NAME, model: model)
-                         .WithApiKey(apiKey);
-
+                         .AddOpenAI(LLM_PROJECT_NAME)
+                         .WithEndpoint($"{string.Join("://", endpoint.Split([':', '/'], StringSplitOptions.RemoveEmptyEntries).Take(2))}/openai/v1/")
+                         .WithApiKey(apiKey)
+                         .AddModel(name: LLM_RESOURCE_NAME, model: deploymentName);
         return source.WithReference(chat)
                      .WaitFor(chat);
     }

--- a/apphost.settings.json
+++ b/apphost.settings.json
@@ -7,7 +7,7 @@
     }
   },
 
-  "LlmProvider": "AzureOpenAI",
+  "LlmProvider": "MicrosoftFoundry",
 
   "GitHub": {
     "Endpoint": "https://models.github.ai/inference",
@@ -20,6 +20,14 @@
       "Endpoint": "{{AZURE_OPENAI_ENDPOINT}}",
       "ApiKey": "{{AZURE_OPENAI_API_KEY}}",
       "DeploymentName": "gpt-5-mini"
+    }
+  },
+
+  "MicrosoftFoundry": {
+    "Project": {
+      "Endpoint": "{{MICROSOFT_FOUNDRY_PROJECT_ENDPOINT}}",
+      "ApiKey": "{{MICROSOFT_FOUNDRY_PROJECT_API_KEY}}",
+      "DeploymentName": "model-router"
     }
   }
 }

--- a/src/InterviewCoach.Agent/Constants.cs
+++ b/src/InterviewCoach.Agent/Constants.cs
@@ -1,0 +1,6 @@
+namespace InterviewCoach.Agent;
+
+public class Constants
+{
+    public const string LlmProvider = "LlmProvider";
+}

--- a/src/InterviewCoach.Agent/InterviewCoach.Agent.csproj
+++ b/src/InterviewCoach.Agent/InterviewCoach.Agent.csproj
@@ -9,7 +9,9 @@
 
   <ItemGroup>
     <PackageReference Include="Aspire.OpenAI" Version="13.*-*" />
+    <PackageReference Include="Azure.Identity" Version="1.*" />
     <PackageReference Include="Microsoft.Agents.AI" Version="1.*-*" />
+    <PackageReference Include="Microsoft.Agents.AI.AzureAI.Persistent" Version="1.*-*" />
     <PackageReference Include="Microsoft.Agents.AI.DevUI" Version="1.*-*" />
     <PackageReference Include="Microsoft.Agents.AI.Hosting" Version="1.*-*" />
     <PackageReference Include="Microsoft.Agents.AI.Hosting.AGUI.AspNetCore" Version="1.*-*" />

--- a/src/InterviewCoach.Agent/Program.cs
+++ b/src/InterviewCoach.Agent/Program.cs
@@ -1,3 +1,10 @@
+using System.ClientModel.Primitives;
+using System.Data.Common;
+
+using Azure.Identity;
+
+using InterviewCoach.Agent;
+
 using Microsoft.Agents.AI;
 using Microsoft.Agents.AI.DevUI;
 using Microsoft.Agents.AI.Hosting;
@@ -7,7 +14,12 @@ using Microsoft.Extensions.AI;
 using ModelContextProtocol.Client;
 using ModelContextProtocol.Protocol;
 
+using OpenAI;
+
+#pragma warning disable OPENAI001
+
 var builder = WebApplication.CreateBuilder(args);
+var config = builder.Configuration;
 
 builder.AddServiceDefaults();
 
@@ -73,8 +85,28 @@ builder.Services.AddKeyedSingleton<McpClient>("mcp-interview-data", (sp, obj) =>
     return McpClient.CreateAsync(clientTransport, clientOptions, loggerFactory).GetAwaiter().GetResult();
 });
 
-builder.AddOpenAIClient("chat")
-       .AddChatClient();
+if (config[Constants.LlmProvider] != "MicrosoftFoundry")
+{
+    builder.AddOpenAIClient("chat")
+           .AddChatClient();
+}
+else
+{
+    builder.AddOpenAIClient("chat")
+           .AddChatClient();
+
+//     var connection = new DbConnectionStringBuilder() { ConnectionString = config.GetConnectionString("foundry") };
+//     var endpoint = connection.TryGetValue("Endpoint", out var endpointValue) ? endpointValue?.ToString() : throw new InvalidOperationException("Missing Foundry Endpoint");
+//     // var accessKey = connection.TryGetValue("Key", out var accessKeyValue) ? accessKeyValue?.ToString() : throw new InvalidOperationException("Missing Foundry Key");
+//     var model = connection.TryGetValue("Model", out var modelValue) ? modelValue?.ToString() : throw new InvalidOperationException("Missing Foundry Model");
+//     var options = new OpenAIClientOptions() { Endpoint = new Uri(endpoint!) };
+//     var credential = new DefaultAzureCredential();
+//     var client = new OpenAIClient(new BearerTokenPolicy(credential, "https://ai.azure.com/.default"), options)
+//                     .GetResponsesClient(model!)
+//                     .AsIChatClient();
+
+//     builder.Services.AddSingleton<IChatClient>(client);
+}
 
 builder.AddAIAgent(
     name: "coach",

--- a/src/InterviewCoach.AppHost/AppHost.cs
+++ b/src/InterviewCoach.AppHost/AppHost.cs
@@ -1,5 +1,7 @@
 var builder = DistributedApplication.CreateBuilder(args);
 
+// var foundry = builder.AddBicepTemplate("foundry", "../../infra/foundry.bicep");
+
 var mcpMarkItDown = builder.AddDockerfile(ResourceConstants.McpMarkItDown, "../InterviewCoach.Mcp.MarkItDown/packages/markitdown-mcp")
                            .WithExternalHttpEndpoints()
                            .WithImageTag("latest")
@@ -17,6 +19,7 @@ var mcpInterviewData = builder.AddProject<Projects.InterviewCoach_Mcp_InterviewD
 var agent = builder.AddProject<Projects.InterviewCoach_Agent>(ResourceConstants.Agent)
                    .WithExternalHttpEndpoints()
                    .WithLlmReference(builder.Configuration)
+                   .WithEnvironment(ResourceConstants.LlmProvider, builder.Configuration[ResourceConstants.LlmProvider] ?? string.Empty)
                    .WithReference(mcpMarkItDown.GetEndpoint("http"))
                    .WithReference(mcpInterviewData)
                    .WaitFor(mcpMarkItDown)

--- a/src/InterviewCoach.AppHost/InterviewCoach.AppHost.csproj
+++ b/src/InterviewCoach.AppHost/InterviewCoach.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.1.0">
+<Project Sdk="Aspire.AppHost.Sdk/13.1.1">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -9,6 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Aspire.Hosting.Azure" Version="13.*" />
+    <!-- <PackageReference Include="Aspire.Hosting.Azure.AIFoundry" Version="13.*-*" /> -->
     <PackageReference Include="Aspire.Hosting.GitHub.Models" Version="13.*" />
     <PackageReference Include="Aspire.Hosting.OpenAI" Version="13.*" />
     <PackageReference Include="CommunityToolkit.Aspire.Hosting.SQLite" Version="13.*" />

--- a/src/InterviewCoach.AppHost/LlmResourceFactory.cs
+++ b/src/InterviewCoach.AppHost/LlmResourceFactory.cs
@@ -5,14 +5,17 @@ public static class LlmResourceFactory
     private const string LLM_PROVIDER_KEY = "LlmProvider";
     private const string LLM_PROVIDER_GITHUB = "GitHubModels";
     private const string LLM_PROVIDER_AZURE_OPENAI = "AzureOpenAI";
+    private const string LLM_PROVIDER_MICROSOFT_FOUNDRY = "MicrosoftFoundry";
     private const string SECTION_NAME_GITHUB = "GitHub";
     private const string SECTION_NAME_AZURE_OPENAI = "Azure:OpenAI";
+    private const string SECTION_NAME_MICROSOFT_FOUNDRY = "MicrosoftFoundry:Project";
     private const string ENDPOINT_KEY = "Endpoint";
     private const string TOKEN_KEY = "Token";
     private const string API_KEY_KEY = "ApiKey";
     private const string MODEL_KEY = "Model";
     private const string DEPLOYMENT_NAME_KEY = "DeploymentName";
     private const string API_KEY_RESOURCE_NAME = "apiKey";
+    private const string LLM_PROJECT_NAME = "foundry";
     private const string LLM_SERVICE_NAME = "openai";
     private const string LLM_RESOURCE_NAME = "chat";
 
@@ -23,10 +26,34 @@ public static class LlmResourceFactory
         {
             LLM_PROVIDER_GITHUB => AddGitHubModelsResource(source, config),
             LLM_PROVIDER_AZURE_OPENAI => AddAzureOpenAIResource(source, config),
+            LLM_PROVIDER_MICROSOFT_FOUNDRY => AddMicrosoftFoundryResource(source, config),
             _ => throw new NotSupportedException($"The specified LLM provider '{provider}' is not supported.")
         };
 
         return source;
+    }
+
+    private static IResourceBuilder<ProjectResource> AddGitHubModelsResource(IResourceBuilder<ProjectResource> source, IConfiguration config)
+    {
+        var provider = config[LLM_PROVIDER_KEY];
+
+        var github = config.GetSection(SECTION_NAME_GITHUB);
+        var endpoint = github[ENDPOINT_KEY] ?? throw new InvalidOperationException($"Missing configuration: {SECTION_NAME_GITHUB}:{ENDPOINT_KEY}");
+        var token = github[TOKEN_KEY] ?? throw new InvalidOperationException($"Missing configuration: {SECTION_NAME_GITHUB}:{TOKEN_KEY}");
+        var model = github[MODEL_KEY] ?? throw new InvalidOperationException($"Missing configuration: {SECTION_NAME_GITHUB}:{MODEL_KEY}");
+
+        Console.WriteLine();
+        Console.WriteLine($"\tUsing {provider}: {model}");
+        Console.WriteLine();
+
+        var apiKey = source.ApplicationBuilder
+                           .AddParameter(name: API_KEY_RESOURCE_NAME, value: token, secret: true);
+        var chat = source.ApplicationBuilder
+                         .AddGitHubModel(name: LLM_RESOURCE_NAME, model: model)
+                         .WithApiKey(apiKey);
+
+        return source.WithReference(chat)
+                     .WaitFor(chat);
     }
 
     private static IResourceBuilder<ProjectResource> AddAzureOpenAIResource(IResourceBuilder<ProjectResource> source, IConfiguration config)
@@ -53,25 +80,31 @@ public static class LlmResourceFactory
                      .WaitFor(chat);
     }
 
-    private static IResourceBuilder<ProjectResource> AddGitHubModelsResource(IResourceBuilder<ProjectResource> source, IConfiguration config)
+    private static IResourceBuilder<ProjectResource> AddMicrosoftFoundryResource(IResourceBuilder<ProjectResource> source, IConfiguration config)
     {
-        var provider = config["LlmProvider"];
+        var provider = config[LLM_PROVIDER_KEY];
 
-        var github = config.GetSection(SECTION_NAME_GITHUB);
-        var endpoint = github[ENDPOINT_KEY] ?? throw new InvalidOperationException($"Missing configuration: {SECTION_NAME_GITHUB}:{ENDPOINT_KEY}");
-        var token = github[TOKEN_KEY] ?? throw new InvalidOperationException($"Missing configuration: {SECTION_NAME_GITHUB}:{TOKEN_KEY}");
-        var model = github[MODEL_KEY] ?? throw new InvalidOperationException($"Missing configuration: {SECTION_NAME_GITHUB}:{MODEL_KEY}");
+        var foundry = config.GetSection(SECTION_NAME_MICROSOFT_FOUNDRY);
+        var endpoint = foundry[ENDPOINT_KEY] ?? throw new InvalidOperationException($"Missing configuration: {SECTION_NAME_MICROSOFT_FOUNDRY}:{ENDPOINT_KEY}");
+        var accessKey = foundry[API_KEY_KEY] ?? throw new InvalidOperationException($"Missing configuration: {SECTION_NAME_MICROSOFT_FOUNDRY}:{API_KEY_KEY}");
+        var deploymentName = foundry[DEPLOYMENT_NAME_KEY] ?? throw new InvalidOperationException($"Missing configuration: {SECTION_NAME_MICROSOFT_FOUNDRY}:{DEPLOYMENT_NAME_KEY}");
 
         Console.WriteLine();
-        Console.WriteLine($"\tUsing {provider}: {model}");
+        Console.WriteLine($"\tUsing {provider}: {deploymentName}");
         Console.WriteLine();
 
         var apiKey = source.ApplicationBuilder
-                           .AddParameter(name: API_KEY_RESOURCE_NAME, value: token, secret: true);
+                           .AddParameter(name: API_KEY_RESOURCE_NAME, value: accessKey, secret: true);
         var chat = source.ApplicationBuilder
-                         .AddGitHubModel(name: LLM_RESOURCE_NAME, model: model)
-                         .WithApiKey(apiKey);
-
+                        //  .AddConnectionString(
+                        //      LLM_PROJECT_NAME,
+                        //     //  ReferenceExpression.Create($"Endpoint:{endpoint};Key={accessKey};Model={deploymentName}"));
+                        //     //  ReferenceExpression.Create($"Endpoint={string.Join("://", endpoint.Split([':', '/'], StringSplitOptions.RemoveEmptyEntries).Take(2))}/openai/v1/;Model={deploymentName}"));
+                        //     //  ReferenceExpression.Create($"Endpoint={string.Join("://", endpoint.Split([':', '/'], StringSplitOptions.RemoveEmptyEntries).Take(2))}/openai/v1/;Key={accessKey};Model={deploymentName}"));
+                         .AddOpenAI(LLM_PROJECT_NAME)
+                         .WithEndpoint($"{string.Join("://", endpoint.Split([':', '/'], StringSplitOptions.RemoveEmptyEntries).Take(2))}/openai/v1/")
+                         .WithApiKey(apiKey)
+                         .AddModel(name: LLM_RESOURCE_NAME, model: deploymentName);
         return source.WithReference(chat)
                      .WaitFor(chat);
     }

--- a/src/InterviewCoach.AppHost/ResourceConstants.cs
+++ b/src/InterviewCoach.AppHost/ResourceConstants.cs
@@ -1,5 +1,6 @@
 public class ResourceConstants
 {
+    public const string LlmProvider = "LlmProvider";
     public const string McpMarkItDown = "mcp-markitdown";
     public const string McpInterviewData = "mcp-interview-data";
     public const string Sqlite = "sqlite";

--- a/src/InterviewCoach.AppHost/appsettings.json
+++ b/src/InterviewCoach.AppHost/appsettings.json
@@ -7,7 +7,7 @@
     }
   },
 
-  "LlmProvider": "AzureOpenAI",
+  "LlmProvider": "MicrosoftFoundry",
 
   "GitHub": {
     "Endpoint": "https://models.github.ai/inference",
@@ -20,6 +20,14 @@
       "Endpoint": "{{AZURE_OPENAI_ENDPOINT}}",
       "ApiKey": "{{AZURE_OPENAI_API_KEY}}",
       "DeploymentName": "gpt-5-mini"
+    }
+  },
+
+  "MicrosoftFoundry": {
+    "Project": {
+      "Endpoint": "{{MICROSOFT_FOUNDRY_PROJECT_ENDPOINT}}",
+      "ApiKey": "{{MICROSOFT_FOUNDRY_PROJECT_API_KEY}}",
+      "DeploymentName": "model-router"
     }
   }
 }

--- a/src/InterviewCoach.WebUI/Components/Pages/Chat/Chat.razor
+++ b/src/InterviewCoach.WebUI/Components/Pages/Chat/Chat.razor
@@ -10,7 +10,7 @@
 
 <ChatMessageList Messages="@messages" InProgressMessage="@currentResponseMessage">
     <NoMessagesContent>
-        <div>I'm your friendly interview coach. To get started, upload your resume and job description.</div>
+        <div>I'm your friendly interview coach. To get started, enter the link or text of your resume and job description.</div>
     </NoMessagesContent>
 </ChatMessageList>
 


### PR DESCRIPTION
## Purpose
* Add Microsoft Foundry as a new LLM provider option and set it as the default connector
* Introduce `MicrosoftFoundry` configuration section with project endpoint, API key, and deployment name (`model-router`) across both file-based (`apphost.cs`) and project-based (`AppHost.csproj`) Aspire hosts
* Add `AddMicrosoftFoundryResource` method to `LlmResourceFactory` to wire up the Foundry OpenAI-compatible endpoint
* Pass `LlmProvider` environment variable to the Agent project so it can branch on the provider at runtime
* Add `Azure.Identity` and `Microsoft.Agents.AI.AzureAI.Persistent` package references to the Agent project for Foundry support
* Update README to make Microsoft Foundry the primary "Set Connection to LLM" option, reorganise Azure OpenAI and GitHub Models as collapsible alternatives, and add Foundry-related documentation links
* Bump Aspire SDK from 13.1.0 to 13.1.1 and add `Aspire.Hosting.Azure` package
* Update `Chat.razor` welcome message to reflect link/text input instead of file upload
* Change Aspire run commands in README from `dotnet run` to `aspire run`

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
* Get the code

```
git clone https://github.com/Azure-Samples/interview-coach-agent-framework.git
cd interview-coach-agent-framework
git checkout feat/foundry-agent
dotnet restore
```

* Test the code
1. Configure Microsoft Foundry credentials via user secrets:
   ```bash
   dotnet user-secrets --file ./apphost.cs set MicrosoftFoundry:Project:Endpoint $MICROSOFT_FOUNDRY_PROJECT_ENDPOINT
   dotnet user-secrets --file ./apphost.cs set MicrosoftFoundry:Project:ApiKey $MICROSOFT_FOUNDRY_PROJECT_API_KEY
   ```
2. Run the Aspire host:
   ```bash
   aspire run --file ./apphost.cs
   ```
3. Verify the agent starts and connects to the Foundry model router endpoint.
4. Optionally switch `LlmProvider` in `apphost.settings.json` to `GitHubModels` or `AzureOpenAI` and verify those paths still work.

## What to Check
Verify that the following are valid
* Microsoft Foundry provider is correctly wired and functional as the default LLM connector
* Existing GitHub Models and Azure OpenAI providers still work when selected
* README instructions accurately reflect the new setup flow
* Aspire dashboard shows the agent connected to the configured LLM provider

## Other Information
* Some commented-out code exists in `Program.cs` and `LlmResourceFactory.cs` for future `DefaultAzureCredential` / connection-string-based Foundry integration (work in progress).
