### PR TITLE
Add interview summary export (Markdown and PDF)

### DIFF
--- a/src/InterviewCoach.Agent/InterviewCoach.Agent.csproj
+++ b/src/InterviewCoach.Agent/InterviewCoach.Agent.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="Microsoft.Agents.AI.Workflows" Version="1.*-*" />
     <!-- <PackageReference Include="Microsoft.Agents.AI.GitHub.Copilot" Version="1.*-*" /> -->
     <PackageReference Include="ModelContextProtocol.AspNetCore" Version="0.*-*" />
+    <PackageReference Include="QuestPDF" Version="2026.2.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/InterviewCoach.Agent/Program.cs
+++ b/src/InterviewCoach.Agent/Program.cs
@@ -1,4 +1,6 @@
 using System.Collections.Concurrent;
+using System.Text;
+using System.Text.Json;
 
 using InterviewCoach.Agent;
 
@@ -171,6 +173,25 @@ app.MapGet("/uploads/{fileId}/{fileName}", (string fileId, string fileName) =>
         return Results.NotFound();
 
     return Results.File(entry.Content, entry.ContentType, entry.FileName);
+});
+
+// --- Export Endpoints ---
+app.MapGet("/export/{sessionId}/markdown", async (string sessionId) =>
+{
+    var mcpClient = app.Services.GetRequiredKeyedService<McpClient>("mcp-interview-data");
+    var result = await mcpClient.CallToolAsync("get_formatted_summary", new Dictionary<string, object?>
+    {
+        ["id"] = sessionId
+    });
+
+    var textBlock = result.Content.OfType<TextContentBlock>().FirstOrDefault();
+    if (textBlock is null)
+        return Results.NotFound("Interview session not found.");
+
+    var markdown = textBlock.Text ?? string.Empty;
+    var bytes = Encoding.UTF8.GetBytes(markdown);
+
+    return Results.File(bytes, "text/markdown", $"interview-summary-{sessionId}.md");
 });
 
 await app.RunAsync();

--- a/src/InterviewCoach.Agent/Program.cs
+++ b/src/InterviewCoach.Agent/Program.cs
@@ -4,6 +4,10 @@ using System.Text.Json;
 
 using InterviewCoach.Agent;
 
+using QuestPDF.Fluent;
+using QuestPDF.Helpers;
+using QuestPDF.Infrastructure;
+
 using Microsoft.Agents.AI;
 using Microsoft.Agents.AI.DevUI;
 using Microsoft.Agents.AI.Hosting.AGUI.AspNetCore;
@@ -192,6 +196,81 @@ app.MapGet("/export/{sessionId}/markdown", async (string sessionId) =>
     var bytes = Encoding.UTF8.GetBytes(markdown);
 
     return Results.File(bytes, "text/markdown", $"interview-summary-{sessionId}.md");
+});
+
+app.MapGet("/export/{sessionId}/pdf", async (string sessionId) =>
+{
+    var mcpClient = app.Services.GetRequiredKeyedService<McpClient>("mcp-interview-data");
+    var result = await mcpClient.CallToolAsync("get_formatted_summary", new Dictionary<string, object?>
+    {
+        ["id"] = sessionId
+    });
+
+    var textBlock = result.Content.OfType<TextContentBlock>().FirstOrDefault();
+    if (textBlock is null)
+        return Results.NotFound("Interview session not found.");
+
+    var markdown = textBlock.Text ?? string.Empty;
+    var lines = markdown.Split('\n');
+
+    QuestPDF.Settings.License = LicenseType.Community;
+
+    var pdfBytes = Document.Create(container =>
+    {
+        container.Page(page =>
+        {
+            page.Size(PageSizes.A4);
+            page.Margin(40);
+            page.DefaultTextStyle(x => x.FontSize(11));
+
+            page.Content().Column(column =>
+            {
+                foreach (var line in lines)
+                {
+                    var trimmed = line.TrimEnd('\r');
+
+                    if (trimmed.StartsWith("# "))
+                    {
+                        column.Item().PaddingBottom(10).Text(trimmed[2..])
+                            .FontSize(22).Bold();
+                    }
+                    else if (trimmed.StartsWith("## "))
+                    {
+                        column.Item().PaddingTop(15).PaddingBottom(5).Text(trimmed[3..])
+                            .FontSize(16).Bold();
+                    }
+                    else if (trimmed.StartsWith("**") && trimmed.EndsWith("**"))
+                    {
+                        column.Item().PaddingBottom(3).Text(trimmed.Trim('*'))
+                            .Bold();
+                    }
+                    else if (trimmed == "---")
+                    {
+                        column.Item().PaddingVertical(8).LineHorizontal(0.5f).LineColor(Colors.Grey.Medium);
+                    }
+                    else if (trimmed.StartsWith("*") && trimmed.EndsWith("*"))
+                    {
+                        column.Item().PaddingBottom(3).Text(trimmed.Trim('*'))
+                            .Italic().FontColor(Colors.Grey.Darken1);
+                    }
+                    else if (!string.IsNullOrWhiteSpace(trimmed))
+                    {
+                        column.Item().PaddingBottom(3).Text(trimmed);
+                    }
+                }
+            });
+
+            page.Footer().AlignCenter().Text(text =>
+            {
+                text.Span("Page ");
+                text.CurrentPageNumber();
+                text.Span(" of ");
+                text.TotalPages();
+            });
+        });
+    }).GeneratePdf();
+
+    return Results.File(pdfBytes, "application/pdf", $"interview-summary-{sessionId}.pdf");
 });
 
 await app.RunAsync();

--- a/src/InterviewCoach.Mcp.InterviewData/InterviewSessionRepository.cs
+++ b/src/InterviewCoach.Mcp.InterviewData/InterviewSessionRepository.cs
@@ -11,6 +11,7 @@ public interface IInterviewSessionRepository
     Task<InterviewSession?> GetInterviewSessionAsync(Guid id);
     Task<InterviewSession?> UpdateInterviewSessionAsync(InterviewSession interviewSession);
     Task<InterviewSession?> CompleteInterviewSessionAsync(Guid id);
+    Task<string?> GetFormattedSummaryAsync(Guid id);
 }
 
 public class InterviewSessionRepository(InterviewDataDbContext db) : IInterviewSessionRepository
@@ -90,5 +91,86 @@ public class InterviewSessionRepository(InterviewDataDbContext db) : IInterviewS
         await db.SaveChangesAsync();
 
         return record;
+    }
+
+    public async Task<string?> GetFormattedSummaryAsync(Guid id)
+    {
+        var record = await db.InterviewSessions.SingleOrDefaultAsync(p => p.Id == id);
+        if (record is null)
+        {
+            return default;
+        }
+
+        var sb = new StringBuilder();
+        sb.AppendLine("# Interview Session Summary");
+        sb.AppendLine();
+        sb.AppendLine($"**Session ID:** {record.Id}");
+        sb.AppendLine($"**Date:** {record.CreatedAt:yyyy-MM-dd HH:mm} UTC");
+        sb.AppendLine($"**Status:** {(record.IsCompleted ? "Completed" : "In Progress")}");
+        sb.AppendLine();
+
+        if (!string.IsNullOrWhiteSpace(record.ResumeLink))
+        {
+            sb.AppendLine("---");
+            sb.AppendLine();
+            sb.AppendLine("## Resume");
+            sb.AppendLine();
+            sb.AppendLine($"**Source:** {record.ResumeLink}");
+            if (!string.IsNullOrWhiteSpace(record.ResumeText))
+            {
+                sb.AppendLine();
+                sb.AppendLine(record.ResumeText.Trim());
+            }
+            sb.AppendLine();
+        }
+        else if (record.ProceedWithoutResume)
+        {
+            sb.AppendLine("---");
+            sb.AppendLine();
+            sb.AppendLine("## Resume");
+            sb.AppendLine();
+            sb.AppendLine("*Proceeded without resume.*");
+            sb.AppendLine();
+        }
+
+        if (!string.IsNullOrWhiteSpace(record.JobDescriptionLink))
+        {
+            sb.AppendLine("---");
+            sb.AppendLine();
+            sb.AppendLine("## Job Description");
+            sb.AppendLine();
+            sb.AppendLine($"**Source:** {record.JobDescriptionLink}");
+            if (!string.IsNullOrWhiteSpace(record.JobDescriptionText))
+            {
+                sb.AppendLine();
+                sb.AppendLine(record.JobDescriptionText.Trim());
+            }
+            sb.AppendLine();
+        }
+        else if (record.ProceedWithoutJobDescription)
+        {
+            sb.AppendLine("---");
+            sb.AppendLine();
+            sb.AppendLine("## Job Description");
+            sb.AppendLine();
+            sb.AppendLine("*Proceeded without job description.*");
+            sb.AppendLine();
+        }
+
+        if (!string.IsNullOrWhiteSpace(record.Transcript))
+        {
+            sb.AppendLine("---");
+            sb.AppendLine();
+            sb.AppendLine("## Interview Transcript");
+            sb.AppendLine();
+            sb.AppendLine(record.Transcript.Trim());
+            sb.AppendLine();
+        }
+
+        sb.AppendLine("---");
+        sb.AppendLine();
+        sb.AppendLine($"*Generated on {DateTimeOffset.UtcNow:yyyy-MM-dd HH:mm} UTC*");
+
+        return sb.ToString();
     }
 }

--- a/src/InterviewCoach.Mcp.InterviewData/InterviewSessionTool.cs
+++ b/src/InterviewCoach.Mcp.InterviewData/InterviewSessionTool.cs
@@ -11,6 +11,7 @@ public interface IInterviewSessionTool
     Task<InterviewSession?> GetInterviewSessionAsync(Guid id);
     Task<InterviewSession?> UpdateInterviewSessionAsync(InterviewSession record);
     Task<InterviewSession?> CompleteInterviewSessionAsync(Guid id);
+    Task<string?> GetFormattedSummaryAsync(Guid id);
 }
 
 [McpServerToolType]
@@ -95,5 +96,24 @@ public class InterviewSessionTool(IInterviewSessionRepository repository, ILogge
         logger.LogInformation("Completed interview session: '{id}'", id);
 
         return completed;
+    }
+
+    [McpServerTool(Name = "get_formatted_summary", Title = "Get a formatted interview summary")]
+    [Description("Gets a formatted Markdown summary of a completed interview session, including session metadata, resume, job description, and full transcript.")]
+    public async Task<string?> GetFormattedSummaryAsync(
+        [Description("The ID of the interview session")] Guid id
+    )
+    {
+        var summary = await repository.GetFormattedSummaryAsync(id);
+        if (summary is null)
+        {
+            logger.LogWarning("Interview session with ID '{id}' not found.", id);
+
+            return default;
+        }
+
+        logger.LogInformation("Generated formatted summary for interview session '{id}'", id);
+
+        return summary;
     }
 }

--- a/src/InterviewCoach.WebUI/Components/Pages/Chat/Chat.razor
+++ b/src/InterviewCoach.WebUI/Components/Pages/Chat/Chat.razor
@@ -4,6 +4,8 @@
 @inject IChatClient ChatClient
 @inject ILogger<Chat> Logger
 @inject FileUploadService FileUploadService
+@inject IHttpClientFactory HttpClientFactory
+@inject IJSRuntime JS
 @implements IDisposable
 
 <PageTitle>Chat</PageTitle>
@@ -16,6 +18,25 @@
             description.</div>
         </NoMessagesContent>
     </ChatMessageList>
+
+    @if (isInterviewComplete)
+    {
+        <div class="export-container page-width">
+            <span>Download your interview summary:</span>
+            <button class="btn-default" @onclick="@(() => DownloadExportAsync("markdown"))">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" style="width:16px;height:16px;display:inline;">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12m4.5 4.5V3" />
+                </svg>
+                Markdown
+            </button>
+            <button class="btn-default" @onclick="@(() => DownloadExportAsync("pdf"))">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" style="width:16px;height:16px;display:inline;">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12m4.5 4.5V3" />
+                </svg>
+                PDF
+            </button>
+        </div>
+    }
 
     <div class="chat-container">
         <ChatInput OnSend="@AddUserMessageAsync" @ref="@chatInput" />
@@ -36,6 +57,15 @@
     private CancellationTokenSource? currentResponseCancellation;
     private ChatMessage? currentResponseMessage;
     private ChatInput? chatInput;
+    private bool isInterviewComplete;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            await JS.InvokeVoidAsync("import", "./Components/Pages/Chat/Chat.razor.js");
+        }
+    }
 
     protected override void OnInitialized()
     {
@@ -92,6 +122,20 @@ currentResponseCancellation.Token);
 
         messages.Add(currentResponseMessage!);
         statefulMessageCount = chatOptions.ConversationId is not null ? messages.Count : 0;
+
+        var assistantText = currentResponseMessage?.Text;
+        if (!isInterviewComplete && !string.IsNullOrEmpty(assistantText))
+        {
+            var lowerText = assistantText.ToLower();
+            if (lowerText.Contains("interview is complete") || lowerText.Contains("interview session complete")
+                || lowerText.Contains("completed your interview") || lowerText.Contains("session has been completed")
+                || lowerText.Contains("interview summary"))
+            {
+                isInterviewComplete = true;
+                StateHasChanged();
+            }
+        }
+
         currentResponseMessage = null;
     }
 
@@ -144,6 +188,7 @@ ChatMessage responseMessage, CancellationToken cancellationToken)
         AddSessionSystemMessages();
         chatOptions.ConversationId = sessionId;
         statefulMessageCount = 0;
+        isInterviewComplete = false;
         await chatInput!.FocusAsync();
     }
 
@@ -174,6 +219,26 @@ ChatMessage responseMessage, CancellationToken cancellationToken)
                                             ReferenceEquals(m, sessionIdMessage) == false));
 
         return outboundMessages;
+    }
+
+    private async Task DownloadExportAsync(string format)
+    {
+        var client = HttpClientFactory.CreateClient("agent");
+        var url = $"export/{sessionId}/{format}";
+        var response = await client.GetAsync(url);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            Logger.LogWarning("Export failed with status {StatusCode}", response.StatusCode);
+            return;
+        }
+
+        var bytes = await response.Content.ReadAsByteArrayAsync();
+        var contentType = format == "pdf" ? "application/pdf" : "text/markdown";
+        var fileName = $"interview-summary-{sessionId}.{(format == "pdf" ? "pdf" : "md")}";
+
+        using var streamRef = new DotNetStreamReference(new MemoryStream(bytes));
+        await JS.InvokeVoidAsync("downloadFileFromStream", fileName, streamRef);
     }
 
     public void Dispose()

--- a/src/InterviewCoach.WebUI/Components/Pages/Chat/Chat.razor.js
+++ b/src/InterviewCoach.WebUI/Components/Pages/Chat/Chat.razor.js
@@ -1,0 +1,12 @@
+window.downloadFileFromStream = async (fileName, dotNetStreamRef) => {
+    const arrayBuffer = await dotNetStreamRef.arrayBuffer();
+    const blob = new Blob([arrayBuffer]);
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = fileName;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+};


### PR DESCRIPTION
Adds the ability to download a completed interview session as a Markdown or PDF file, so users can review feedback offline and share with mentors.

  ### What Changed

  - **New MCP tool:** `get_formatted_summary` in InterviewData MCP server that fetches a session and returns structured Markdown (metadata, resume, JD, transcript)
  - **Markdown export endpoint:** GET /export/{sessionId}/markdown on Agent service
  - **PDF export endpoint:** GET /export/{sessionId}/pdf using QuestPDF with styled headings, horizontal rules, and page numbers
  - **Download buttons in Chat UI:** Markdown and PDF buttons appear after the interview is completed, triggering a browser file download