### PR TITLE
Fix typo in devcontainer storage host requirement

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -62,6 +62,6 @@
   "hostRequirements": {
     "cpus": 4,
     "memory": "16gb",
-    "storage": "32bg"
+    "storage": "32gb"
   }
 }


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Fix a typo in `.devcontainer/devcontainer.json` where the `storage` host requirement was set to `"32bg"` instead of `"32gb"`. This ensures the dev container's storage requirement is correctly parsed and enforced.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Get the code

```bash
git clone https://github.com/Azure-Samples/interview-coach-agent-framework
cd interview-coach-agent-framework
git checkout fix/devcontainer
dotnet restore
dotnet build
```

* Test the code
```bash
aspire run --file ./apphost.cs
# OR
aspire run --project ./src/InterviewCoach.AppHost
```

## What to Check

Verify that the following are valid

* `.devcontainer/devcontainer.json` `hostRequirements.storage` value reads `"32gb"`.
* Dev container rebuilds successfully with no parsing warnings related to the storage requirement.

## Other Information
<!-- Add any other helpful information that may be needed here. -->
Single-character typo fix; no functional code changes.