### PR TITLE
Only enable SqliteWeb in run mode

### DIFF
--- a/docs/providers/MICROSOFT-FOUNDRY.md
+++ b/docs/providers/MICROSOFT-FOUNDRY.md
@@ -57,6 +57,7 @@ aspire run --file ./apphost.cs
 # Using project-based Aspire
 aspire run --project ./src/InterviewCoach.AppHost
 ```
+
 ## Step 5: Deploy to Azure
 
 ```bash

--- a/src/InterviewCoach.AppHost/AppHost.cs
+++ b/src/InterviewCoach.AppHost/AppHost.cs
@@ -7,8 +7,11 @@ var mcpMarkItDown = builder.AddContainer(ResourceConstants.McpMarkItDown, "mcp/m
                            .WithHttpEndpoint(3001, 3001)
                            .WithArgs("--http", "--host", "0.0.0.0", "--port", "3001");
 
-var sqlite = builder.AddSqlite(ResourceConstants.Sqlite, databaseFileName: ResourceConstants.DatabaseName)
-                    .WithSqliteWeb();
+var sqlite = builder.AddSqlite(ResourceConstants.Sqlite, databaseFileName: ResourceConstants.DatabaseName);
+if (builder.ExecutionContext.IsRunMode)
+{
+    sqlite.WithSqliteWeb();
+}
 
 var mcpInterviewData = builder.AddProject<Projects.InterviewCoach_Mcp_InterviewData>(ResourceConstants.McpInterviewData)
                               .WithExternalHttpEndpoints()


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Restrict the `WithSqliteWeb()` companion container to Aspire **run mode** only, so it isn't provisioned during publish/deploy where it isn't needed.
* Minor docs cleanup: add a missing blank line before the "Step 5: Deploy to Azure" heading in `docs/providers/MICROSOFT-FOUNDRY.md` for proper Markdown rendering.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Get the code

```bash
git clone https://github.com/Azure-Samples/interview-coach-agent-framework.git
cd interview-coach-agent-framework
git checkout fix/sqlite-web-run-mode-only
dotnet restore
dotnet build
```

* Test the code
```bash
aspire run --file ./apphost.cs
# OR
aspire run --project ./src/InterviewCoach.AppHost
```

## What to Check

Verify that the following are valid

* When running locally (`aspire run`), the SqliteWeb companion resource is available as before.
* When publishing/deploying (e.g. `azd up`), the SqliteWeb resource is not included.
* The Microsoft Foundry provider doc renders correctly around the "Step 5" heading.

## Other Information
<!-- Add any other helpful information that may be needed here. -->
